### PR TITLE
Fix compile issues when importing the library in Swift

### DIFF
--- a/AMQPObject.h
+++ b/AMQPObject.h
@@ -19,7 +19,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <amqp.h>
+#import "amqp.h"
 
 @interface AMQPObject : NSObject
 

--- a/rabbitmq-c/amqp.h
+++ b/rabbitmq-c/amqp.h
@@ -729,7 +729,7 @@ typedef enum {
 
 AMQP_END_DECLS
 
-#include <amqp_framing.h>
+#include "amqp_framing.h"
 
 AMQP_BEGIN_DECLS
 

--- a/rabbitmq-c/amqp_framing.h
+++ b/rabbitmq-c/amqp_framing.h
@@ -37,7 +37,7 @@
 #ifndef AMQP_FRAMING_H
 #define AMQP_FRAMING_H
 
-#include <amqp.h>
+#include "amqp.h"
 
 AMQP_BEGIN_DECLS
 

--- a/rabbitmq-c/amqp_ssl_socket.h
+++ b/rabbitmq-c/amqp_ssl_socket.h
@@ -25,7 +25,7 @@
 #ifndef AMQP_SSL_H
 #define AMQP_SSL_H
 
-#include <amqp.h>
+#include "amqp.h"
 
 AMQP_BEGIN_DECLS
 

--- a/rabbitmq-c/amqp_tcp_socket.h
+++ b/rabbitmq-c/amqp_tcp_socket.h
@@ -29,7 +29,7 @@
 #ifndef AMQP_TCP_SOCKET_H
 #define AMQP_TCP_SOCKET_H
 
-#include <amqp.h>
+#include "amqp.h"
 
 AMQP_BEGIN_DECLS
 


### PR DESCRIPTION
Hi.  
Importing this library in a Swift project as a dynamic framework (using cocoapods' `use_frameworks!` directive) causes a compile error. 
This PR fixes the issue by replacing the brackets with quotes in the import statements, where appropriate.  

Cheers.
